### PR TITLE
Update LS-out-ITU-reply to-1983.md

### DIFF
--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -19,7 +19,6 @@ Also, the correct names for these RFCs are as follows:
    * RFC 8665: OSPF Extensions for Segment Routing
    * RFC 8666: OSPFv3 Extensions for Segment Routing
    * RFC 8667: IS-IS Extensions for Segment Routing
-the publication process with the RFC Editor.
 
 Note that some other SRv6-related specifications are being finalized by SPRING.
 Notably, "Compressed SRv6 Segment List Encoding (CSID)" [3] has been approved

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -16,7 +16,9 @@ Unlike what is stated in the report, some of the listed RFCs (e.g., RFC 8665, 86
 apply for SRv6 but for SR-MPLS. Some RFCs (e.g., RFC 9256) apply for both SRv6 and SR-MPLS.
 A review of the RFCs listed on the WGs pages will provide information on their applicability to SRv6.
 Also, the correct names for these RFCs are as follows:
-
+   * RFC 8665: OSPF Extensions for Segment Routing
+   * RFC 8666: OSPFv3 Extensions for Segment Routing
+   * RFC 8667: IS-IS Extensions for Segment Routing
 Note that some other SRv6-related specifications (notably, "Compressed SRv6 Segment
 List Encoding (CSID) [3]) may be approved for publication as an RFC and are under
 the publication process with the RFC Editor.

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -24,7 +24,7 @@ List Encoding (CSID) [3]) may be approved for publication as an RFC and are unde
 the publication process with the RFC Editor.
 
 When referring to aspects of the IETF standards as "mandatory" or "optional", it is recommended to 
-also provide a reference to the specific section and text from the specific RFC. This will
+provide a reference to the specific section and text from the specific RFC. This will
 avoid misalignment with IETF standards. E.g., RFC 8754 does not specify the usage of Tag in 
 the SRH (it only introduces the Tag field in the SRH) but the document marks 
 'Packet Tagging and Tag Processing' as mandatory. There are other similar misalignments.

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -9,7 +9,7 @@ the LS are a subset of SRv6-related Proposed Standards published so far by the I
 identify a subset of SRv6-related specifications as "Core SRv6 Standards". 
 There are several Working Groups (WGs) in the IETF 
 (mainly SPRING, 6MAN, BMWG, BESS, IDR, LSR, PCE, RTGWG, TEAS, and OPSAWG) that are working
-on SRv6 related specifications. The links to all active IETF WGs can be found at [2].
+on SRv6-related specifications. The links to all active IETF WGs can be found at [2].
 Further, the list of RFCs published by each of the WG are available on each WG's page.
 
 Unlike what is stated in the report, some of the listed RFCs (e.g., RFC 8665, 8666, and 8667) do not

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -8,7 +8,7 @@ The specifications listed as "Core SRv6 Standards" in the attached document to
 the LS are a subset of SRv6-related Proposed Standards published so far by the IETF. The IETF does not
 identify a subset of SRv6-related specifications as "Core SRv6 Standards". 
 There are several Working Groups (WGs) in the IETF 
-(mainly spring, 6man, bess, idr, lsr, pce, rtgwg, teas, and opsawg) that are working
+(mainly SPRING, 6MAN, BMWG, BESS, IDR, LSR, PCE, RTGWG, TEAS, and OPSAWG) that are working
 on SRv6 related specifications. The links to all active IETF WGs can be found at [2].
 Further, the list of RFCs published by each of the WG are available on each WG's page.
 

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -5,20 +5,27 @@ technology: Segment Routing over IPv6 (SRv6). We acknoweldge that the technical 
 does not aim to alter any SRv6 specification or seek to specify new SRv6 requirements outside of IETF's work.
 
 The specifications listed as "Core SRv6 Standards" in the attached document to
-the LS are a subset of SRv6-related Proposed Standards published so far by the IETF.
-These RFCs were produced by several Working Groups (WGs), mainly SPRING, 6MAN, and OPSAWG.
-The full list of published RFCs can be retrieved from [2].
+the LS are a subset of SRv6-related Proposed Standards published so far by the IETF. The IETF does not
+identify a subset of SRv6-related specifications as "Core SRv6 Standards". 
+At the time of this LS response, there are several Working Groups (WGs) in the IETF 
+(mainly spring, 6man, bess, idr, lsr, pce, rtgwg, teas, and opsawg) that are working
+on SRv6 related specifications. The links to all active IETF WGs can be found at [2].
+Further, the list of RFCs published by each of the WG are available on each WG's page.
 
 Unlike what is stated in the report, some of the listed RFCs (e.g., RFC 8665, 8666, and 8667) do not
-apply with an IPv6 data plane. Also, the correct names for these RFCs are as follows:
+apply for SRv6 but for SR-MPLS. Some RFCs (e.g., RFC 9256) apply for both SRv6 and SR-MPLS.
+A review of the RFCs listed on the WGs pages will provide information on their applicability to SRv6.
+Also, the correct names for these RFCs are as follows:
 
-   * RFC 8665: OSPF Extensions for Segment Routing
-   * RFC 8666: OSPFv3 Extensions for Segment Routing
-   * RFC 8667: IS-IS Extensions for Segment Routing
+Note that some other SRv6-related specifications (notably, "Compressed SRv6 Segment
+List Encoding (CSID) [3]) may be approved for publication as an RFC and are under
+the publication process with the RFC Editor.
 
-Note that some other SRv6-related specifications are being finalized by SPRING.
-Notably, "Compressed SRv6 Segment List Encoding (CSID)" [3] has been approved
-and is planned for publication by the IETF in the coming few months.
+When referring to aspects of the IETF standards as "mandatory" or "optional", it is recommended to 
+also provide a reference to the specific section and text from the specific RFC. This will
+avoid misalignment with IETF standards. E.g., RFC 8754 does not specify the usage of Tag in 
+the SRH (it only introduces the Tag field in the SRH) but the document marks 
+'Packet Tagging and Tag Processing' as mandatory. There are other similar misalignments.
 
 While ensuring better interoperability is one of the key objectives of the IETF
 specifications, the IETF does not produce formal conformance test suites per se. However, the IETF
@@ -34,7 +41,6 @@ and progressing any work.
 
 For specific questions related to a given SRv6-related specification, we encourage
 the use of the mailing list of the WG that produced that specification.
- 
 
 OPS Area Directors: Mohamed Boucadair & Mahesh Jethanandani
 Routing Area Directors: Gunter Van de Velde, Jim Guichard, & Ketan Talaulikar
@@ -46,7 +52,7 @@ OPSAWG WG Chairs: Benoît Claise, Joe Clarke
 6MAN WG Chairs: Bob Hinden, Jen Linkova
 
 * [1] https://datatracker.ietf.org/liaison/1983/
-* [2] https://datatracker.ietf.org/
+* [2] https://datatracker.ietf.org/wg/
 * [3] https://datatracker.ietf.org/doc/draft-ietf-spring-srv6-srh-compression/
 * [4] https://datatracker.ietf.org/group/bmwg/about/
 * [5] https://datatracker.ietf.org/doc/draft-ietf-bmwg-sr-bench-meth/

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -25,7 +25,7 @@ Notably, "Compressed SRv6 Segment List Encoding (CSID)" [3] has been approved
 and is planned for publication by the IETF in the coming few months.
 When referring to aspects of the IETF standards as "mandatory" or "optional", it is recommended to 
 provide a reference to the specific section and text from the specific RFC. This will
-avoid misalignment with IETF standards. E.g., RFC 8754 does not specify the usage of Tag in 
+avoid misalignment with IETF standards. For example, RFC 8754 does not specify the usage of "Tag" in 
 the SRH (it only introduces the Tag field in the SRH) but the ITU document marks 
 'Packet Tagging and Tag Processing' as mandatory. There are other similar misalignments.
 

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -20,7 +20,6 @@ Also, the correct names for these RFCs are as follows:
    * RFC 8666: OSPFv3 Extensions for Segment Routing
    * RFC 8667: IS-IS Extensions for Segment Routing
 Note that some other SRv6-related specifications (notably, "Compressed SRv6 Segment
-List Encoding (CSID) [3]) may be approved for publication as an RFC and are under
 the publication process with the RFC Editor.
 
 Note that some other SRv6-related specifications are being finalized by SPRING.

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -7,7 +7,7 @@ does not aim to alter any SRv6 specification or seek to specify new SRv6 require
 The specifications listed as "Core SRv6 Standards" in the attached document to
 the LS are a subset of SRv6-related Proposed Standards published so far by the IETF. The IETF does not
 identify a subset of SRv6-related specifications as "Core SRv6 Standards". 
-At the time of this LS response, there are several Working Groups (WGs) in the IETF 
+There are several Working Groups (WGs) in the IETF 
 (mainly spring, 6man, bess, idr, lsr, pce, rtgwg, teas, and opsawg) that are working
 on SRv6 related specifications. The links to all active IETF WGs can be found at [2].
 Further, the list of RFCs published by each of the WG are available on each WG's page.

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -26,7 +26,7 @@ the publication process with the RFC Editor.
 When referring to aspects of the IETF standards as "mandatory" or "optional", it is recommended to 
 provide a reference to the specific section and text from the specific RFC. This will
 avoid misalignment with IETF standards. E.g., RFC 8754 does not specify the usage of Tag in 
-the SRH (it only introduces the Tag field in the SRH) but the document marks 
+the SRH (it only introduces the Tag field in the SRH) but the ITU document marks 
 'Packet Tagging and Tag Processing' as mandatory. There are other similar misalignments.
 
 While ensuring better interoperability is one of the key objectives of the IETF

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -19,7 +19,6 @@ Also, the correct names for these RFCs are as follows:
    * RFC 8665: OSPF Extensions for Segment Routing
    * RFC 8666: OSPFv3 Extensions for Segment Routing
    * RFC 8667: IS-IS Extensions for Segment Routing
-Note that some other SRv6-related specifications (notably, "Compressed SRv6 Segment
 the publication process with the RFC Editor.
 
 Note that some other SRv6-related specifications are being finalized by SPRING.

--- a/LS-out-ITU-reply to-1983.md
+++ b/LS-out-ITU-reply to-1983.md
@@ -23,6 +23,9 @@ Note that some other SRv6-related specifications (notably, "Compressed SRv6 Segm
 List Encoding (CSID) [3]) may be approved for publication as an RFC and are under
 the publication process with the RFC Editor.
 
+Note that some other SRv6-related specifications are being finalized by SPRING.
+Notably, "Compressed SRv6 Segment List Encoding (CSID)" [3] has been approved
+and is planned for publication by the IETF in the coming few months.
 When referring to aspects of the IETF standards as "mandatory" or "optional", it is recommended to 
 provide a reference to the specific section and text from the specific RFC. This will
 avoid misalignment with IETF standards. E.g., RFC 8754 does not specify the usage of Tag in 


### PR DESCRIPTION
Some further suggestions for text improvements for the following:

- to convey that IETF does not identify core vs non-core specifications
- to convey they are missing several WGs that are working on SRv6 related specifications
- to convey that they have misunderstood and misrepresented certain IETF standards.